### PR TITLE
fix: return a bool as specified in function header

### DIFF
--- a/casino-dapp/truffle/contracts/flipcontract.sol
+++ b/casino-dapp/truffle/contracts/flipcontract.sol
@@ -27,6 +27,7 @@ contract FlipContract is Ownable {
             win = false;
         }
         emit bet(msg.sender, msg.value, win, side);
+        return win;
     }
     // Function to Withdraw Funds
     function withdrawAll() public onlyOwner returns(uint){


### PR DESCRIPTION
This fixes an inconsistency between the specified return type and returned data. Otherwise, the compiler might fail.