### PR TITLE
update flipcontract.sol

### DIFF
--- a/casino-dapp/truffle/contracts/flipcontract.sol
+++ b/casino-dapp/truffle/contracts/flipcontract.sol
@@ -1,5 +1,5 @@
 import "../node_modules/@openzeppelin/contracts/access/Ownable.sol";
-import "../node_modules/@openzeppelin/contracts/math/SafeMath.sol";
+import "../node_modules/@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 pragma solidity ^0.8.9;
 


### PR DESCRIPTION
Correct pathing as compiler was failing otherwise

ParserError: Source "project:/node_modules/@openzeppelin/utils/math/SafeMath.sol" not found
 --> project:/contracts/flipcontract.sol:2:1:
  |
2 | import "../node_modules/@openzeppelin/utils/math/SafeMath.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^